### PR TITLE
[bug] last char of all game responses missing

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -46,7 +46,9 @@ app.post('/games', function(req, res) {
     readFromPid(child.pid, function(data) {
         data = new String(data);
         console.log(data);
-        data = data.substring(0, data.length - 3);
+        // zmachine responds with "\n>" at the end of each command.
+        // so strip off those 2 extra chars
+        data = data.substring(0, data.length - 2);
         response = {
             pid: child.pid,
             data: data
@@ -80,7 +82,9 @@ app.post('/games/:pid/action', function(req, res) {
     writeToPid(pid, req.body.action);
     readFromPid(pid, function(data) {
         data = new String(data);
-        data = data.substring(0, data.length - 3);
+        // zmachine responds with "\n>" at the end of each command.
+        // so strip off those 2 extra chars
+        data = data.substring(0, data.length - 2);
         response = {
             pid: pid,
             data: data
@@ -176,7 +180,7 @@ app.post('/games/:pid/restore', function(req, res) {
                     data = data.substring(0, data.length - 0);
                     failure(data)
                 } else {
-                    data = data.substring(0, data.length - 3);
+                    data = data.substring(0, data.length - 2);
                     response = {
                         pid: pid,
                         data: data


### PR DESCRIPTION
dfrotz returns all game responses ending with "\n>" 

The API fixes this by stripping the last three characters. But since \n is a single newline character and not a literal backslash-n, it's only two characters that need stripping. The last character of every response is cut off.