### PR TITLE
Create dockerignore with dirs that makefile should create

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+frotz
+node_modules


### PR DESCRIPTION
the Dockerfile specifies that `make all` should be run when a container's build, but nothing ends up happening, since both directories that the makefile would create have already been added to the docker container when `ADD . /root` ran. 

By adding these to .dockerignore, they're not added to the container, and so `make all` builds and links frotz and installs all the npm dependencies. 